### PR TITLE
Add caching to get_weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The cached data lasts for 5 minutes.
 
 To run this project, you will need [Docker](https://www.docker.com/) installed. Then, from the directory of the cloned repository, simply run ```docker-compose up```. The API will be exposed locally at the port 5000.
 
+To run in development mode, which automatically runs the tests, use ```docker-compose -f docker-compose.yml -f docker-compose.dev.yml up``` instead. The tests can be rerun by using ```docker start pytest```.
+
 ## Available endpoints
 
 - ```/weather/<city_name>```: Get the weather data for the specified ```city_name```.  If available, cached data is used. Otherwise, new data is fetched from the Open Weather API and cached.

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,6 +2,4 @@ FROM python:3.6
 RUN mkdir /app/
 COPY . /app/
 WORKDIR /app/
-EXPOSE 5000
 RUN pip install -r requirements.txt
-CMD ["python", "api.py"]

--- a/app/api.py
+++ b/app/api.py
@@ -2,6 +2,7 @@ import os
 from flask import Flask, jsonify
 from resources import open_weather
 import data
+import logging
 
 
 api = Flask(__name__)
@@ -24,6 +25,7 @@ def handle_open_weather_city_not_found(e):
 
 @api.errorhandler(Exception)
 def handle_open_weather_fetch_error(e):
+    logging.error(e)
     payload = {
         'message': 'An internal error has occurred. '
                    'Please, contact the system administrator.',

--- a/app/data.py
+++ b/app/data.py
@@ -2,12 +2,16 @@
 # from the Open Weather API
 
 from resources import open_weather
+from resources.mongo_db import WeatherCache
 from typing import List
 
 
 def get_weather(city_name: str) -> dict:
-    # TODO: switch fetching between Open Weather API and cached DB
-    return open_weather.get_weather_from_city_name(city_name)
+    weather = WeatherCache.read_weather(city_name)
+    if not weather:
+        weather = open_weather.get_weather_from_city_name(city_name)
+        WeatherCache.update_or_insert_weather(weather)
+    return weather
 
 
 def get_latest_cached_weathers(max: int = 5) -> List[dict]:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,2 +1,3 @@
 flask
 requests
+pymongo

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,3 +1,4 @@
 flask
 requests
 pymongo
+pytest

--- a/app/resources/mongo_db.py
+++ b/app/resources/mongo_db.py
@@ -5,12 +5,12 @@ from pymongo import MongoClient, DESCENDING
 class WeatherCache():
 
     @classmethod
-    def init_db(cls, db_uri: str = None) -> None:
-        db_uri = 'mongodb://{}:27017/{}'.format(
-            os.environ['MONGODB_HOSTNAME'],
-            os.environ['MONGODB_DATABASE']
-        ) if not db_uri else db_uri
-        cls._weathers_collection = MongoClient(db_uri).cache.weathers
+    def init_db(cls) -> None:
+        mongo_uri = 'mongodb://{}:27017'.format(
+            os.environ['MONGODB_HOSTNAME']
+        )
+        db_name = os.environ['MONGODB_DATABASE']
+        cls._weathers_collection = MongoClient(mongo_uri)[db_name].weathers
         cls._weathers_collection.create_index('name')
         cls._weathers_collection.create_index([('timestamp', DESCENDING)])
 

--- a/app/resources/mongo_db.py
+++ b/app/resources/mongo_db.py
@@ -3,16 +3,27 @@ from pymongo import MongoClient, DESCENDING
 
 
 class WeatherCache():
+    CACHE_EXPIRATION_TIME = 300  # in seconds
 
     @classmethod
-    def init_db(cls) -> None:
+    def _get_db(cls) -> None:
         mongo_uri = 'mongodb://{}:27017'.format(
             os.environ['MONGODB_HOSTNAME']
         )
         db_name = os.environ['MONGODB_DATABASE']
-        cls._weathers_collection = MongoClient(mongo_uri)[db_name].weathers
-        cls._weathers_collection.create_index('name')
-        cls._weathers_collection.create_index([('timestamp', DESCENDING)])
+        return MongoClient(mongo_uri)[db_name]
+
+    @classmethod
+    def _get_weathers_collection(cls):
+        if not hasattr(cls, '_weathers_collection'):
+            db = cls._get_db()
+            cls._weathers_collection = db.weathers
+            cls._weathers_collection.create_index('name')
+            cls._weathers_collection.create_index(
+                [('timestamp', DESCENDING)],
+                expireAfterSeconds=cls.CACHE_EXPIRATION_TIME
+            )
+        return cls._weathers_collection
 
     @staticmethod
     def _drop_surpluss_attrbs(dict_: dict) -> dict:
@@ -21,7 +32,7 @@ class WeatherCache():
 
     @classmethod
     def update_or_insert_weather(cls, weather):
-        cls._weathers_collection.update_one(
+        cls._get_weathers_collection().update_one(
             {"name": weather['name']},
             {"$set": weather, "$currentDate": {"timestamp": True}},
             upsert=True
@@ -29,14 +40,11 @@ class WeatherCache():
 
     @classmethod
     def read_weather(cls, city_name):
-        weather = cls._weathers_collection.find_one({'name': city_name})
+        weather = cls._get_weathers_collection().find_one({'name': city_name})
         return cls._drop_surpluss_attrbs(weather) if weather else weather
 
     @classmethod
     def read_latest_weathers(cls, max: int = 5):
         return [cls._drop_surpluss_attrbs(weather) for weather in
-                cls._weathers_collection.find().sort('timestamp', DESCENDING).
-                limit(max)]
-
-
-WeatherCache.init_db()
+                cls._get_weathers_collection().find().
+                sort('timestamp', DESCENDING).limit(max)]

--- a/app/resources/mongo_db.py
+++ b/app/resources/mongo_db.py
@@ -1,0 +1,42 @@
+import os
+from pymongo import MongoClient, DESCENDING
+
+
+class WeatherCache():
+
+    @classmethod
+    def init_db(cls, db_uri: str = None) -> None:
+        db_uri = 'mongodb://{}:27017/{}'.format(
+            os.environ['MONGODB_HOSTNAME'],
+            os.environ['MONGODB_DATABASE']
+        ) if not db_uri else db_uri
+        cls._weathers_collection = MongoClient(db_uri).cache.weathers
+        cls._weathers_collection.create_index('name')
+        cls._weathers_collection.create_index([('timestamp', DESCENDING)])
+
+    @staticmethod
+    def _drop_surpluss_attrbs(dict_: dict) -> dict:
+        SURPLUSS_ATTRBS = ['_id', 'timestamp']
+        return {k: v for k, v in dict_.items() if k not in SURPLUSS_ATTRBS}
+
+    @classmethod
+    def update_or_insert_weather(cls, weather):
+        cls._weathers_collection.update_one(
+            {"name": weather['name']},
+            {"$set": weather, "$currentDate": {"timestamp": True}},
+            upsert=True
+        )
+
+    @classmethod
+    def read_weather(cls, city_name):
+        weather = cls._weathers_collection.find_one({'name': city_name})
+        return cls._drop_surpluss_attrbs(weather) if weather else weather
+
+    @classmethod
+    def read_latest_weathers(cls, max: int = 5):
+        return [cls._drop_surpluss_attrbs(weather) for weather in
+                cls._weathers_collection.find().sort('timestamp', DESCENDING).
+                limit(max)]
+
+
+WeatherCache.init_db()

--- a/app/resources/open_weather.py
+++ b/app/resources/open_weather.py
@@ -29,8 +29,4 @@ def get_weather_from_city_name(city_name: str) -> dict:
     elif response.status_code == 404:
         raise CityNotFound(city_name)
     else:
-        content = [response.status_code, response.json()['message']]
-        logging.critical(
-            'Open Weather API fetch error ({}): {}.'.format(*content)
-        )
-        raise FetchError(*content)
+        raise FetchError(response.status_code, response.json()['message'])

--- a/app/resources/open_weather.py
+++ b/app/resources/open_weather.py
@@ -2,7 +2,6 @@
 # valid data
 
 import requests
-import logging
 
 ENDPOINT = 'http://api.openweathermap.org/data/2.5/weather'
 API_KEY = '09d9c578d13c2303e83f7b7f94f12d3f'

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -1,5 +1,6 @@
 import pytest
 from api import api
+from resources import open_weather
 
 VALID_CITY_NAME = 'New York'
 INVALID_CITY_NAME = 'Old York'
@@ -26,3 +27,18 @@ def test_invalid_get_weather(client):
     response_dict = response.get_json()
     assert response_dict['cod'] == 404
     assert 'message' in response_dict
+
+
+def test_get_weather_cacheability(client):
+    response1 = client.get('weather/{}'.format(VALID_CITY_NAME))
+    response1_dict = response1.get_json()
+    open_weather_endpoint = open_weather.ENDPOINT
+    open_weather.ENDPOINT = 'invalid endpoint'  # block Open Weather API use
+    try:
+        response2 = client.get('weather/{}'.format(VALID_CITY_NAME))
+        response2_dict = response2.get_json()
+        assert response1_dict == response2_dict
+    except Exception as e:
+        raise e
+    finally:
+        open_weather.ENDPOINT = open_weather_endpoint

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -1,6 +1,8 @@
 import pytest
 from api import api
 from resources import open_weather
+from resources.mongo_db import WeatherCache
+
 
 VALID_CITY_NAME = 'New York'
 INVALID_CITY_NAME = 'Old York'
@@ -10,6 +12,9 @@ INVALID_CITY_NAME = 'Old York'
 def client():
     api.config['TESTING'] = True
     with api.test_client() as client:
+        WeatherCache._get_db().command("dropDatabase")
+        if hasattr(WeatherCache, '_weathers_collection'):
+            delattr(WeatherCache, '_weathers_collection')
         yield client
 
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+
+    api-service:
+        environment:
+            FLASK_ENV: development
+            FLASK_DEBUG: 1
+
+    db-service:
+        ports:
+            - '27017:27017'
+            
+    api-tests-service:
+        build: ./app/
+        container_name: pytest
+        command: pytest
+        volumes:
+            - './app/:/app/'
+        environment:
+            FLASK_ENV: development
+            FLASK_DEBUG: 1
+            MONGODB_DATABASE: cache_test
+            MONGODB_HOSTNAME: mongodb
+        depends_on:
+            - db-service
+        networks:
+            - backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,42 @@
 version: '3.8'
+
 services:
-  api-service:
-    build: ./app/
-    container_name: flask
-    volumes: 
-      - ./app/:/app/
-    ports: 
-      - 5000:5000
-    environment:
-      PORT: 5000
-      FLASK_ENV: development
-      MONGODB_DATABASE: cache
-      MONGODB_HOSTNAME: mongodb
-      FLASK_DEBUG: 1
-    depends_on:
-      - db-service
-    networks:
-      - backend
-  db-service:
-    image: mongo
-    container_name: mongodb
-    volumes:
-      - mongodbdata:/data/db
-    environment:
-      MONGO_INITDB_DATABASE: cache
-      MONGODB_DATA_DIR: /data/db
-      MONDODB_LOG_DIR: /dev/null
-    networks:
-      - backend
-    ports:
-      - 27017:27017
+
+    api-service:
+        build: ./app/
+        container_name: flask
+        volumes:
+            - './app/:/app/'
+        ports:
+            - '5000:5000'
+        environment:
+            PORT: 5000
+            FLASK_ENV: development
+            MONGODB_DATABASE: cache
+            MONGODB_HOSTNAME: mongodb
+            FLASK_DEBUG: 1
+        depends_on:
+            - db-service
+        networks:
+            - backend
+
+    db-service:
+        image: mongo
+        container_name: mongodb
+        volumes:
+            - 'mongodbdata:/data/db'
+        environment:
+            MONGO_INITDB_DATABASE: cache
+            MONGODB_DATA_DIR: /data/db
+            MONDODB_LOG_DIR: /dev/null
+        networks:
+            - backend
+        ports:
+            - '27017:27017'
+
 networks:
-  backend:
-    driver: bridge
+    backend:
+        driver: bridge
 volumes:
-  mongodbdata:
-    driver: local
+    mongodbdata:
+        driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,16 +5,15 @@ services:
     api-service:
         build: ./app/
         container_name: flask
+        command: python api.py
         volumes:
             - './app/:/app/'
         ports:
             - '5000:5000'
         environment:
             PORT: 5000
-            FLASK_ENV: development
             MONGODB_DATABASE: cache
             MONGODB_HOSTNAME: mongodb
-            FLASK_DEBUG: 1
         depends_on:
             - db-service
         networks:
@@ -31,8 +30,6 @@ services:
             MONDODB_LOG_DIR: /dev/null
         networks:
             - backend
-        ports:
-            - '27017:27017'
 
 networks:
     backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,38 @@
 version: '3.8'
-services: 
-    api-service:
-        build: ./app/
-        volumes: 
-            - ./app/:/app/
-        ports: 
-            - 5000:5000
-        environment:
-            PORT: 5000
-            FLASK_ENV: development
-            FLASK_DEBUG: 1
+services:
+  api-service:
+    build: ./app/
+    container_name: flask
+    volumes: 
+      - ./app/:/app/
+    ports: 
+      - 5000:5000
+    environment:
+      PORT: 5000
+      FLASK_ENV: development
+      MONGODB_DATABASE: cache
+      MONGODB_HOSTNAME: mongodb
+      FLASK_DEBUG: 1
+    depends_on:
+      - db-service
+    networks:
+      - backend
+  db-service:
+    image: mongo
+    container_name: mongodb
+    volumes:
+      - mongodbdata:/data/db
+    environment:
+      MONGO_INITDB_DATABASE: cache
+      MONGODB_DATA_DIR: /data/db
+      MONDODB_LOG_DIR: /dev/null
+    networks:
+      - backend
+    ports:
+      - 27017:27017
+networks:
+  backend:
+    driver: bridge
+volumes:
+  mongodbdata:
+    driver: local


### PR DESCRIPTION
Added caching to the ```get_weather``` method on ```data.py```, using a new class ```WeatherCache``` on ```resources/mongo_db.py``` to access a MongoDB instance, which runs as a new service ```db-service```.

Also:
- All untreated exceptions (not user responsibility) will now log when rising up to the API layer and return a generic message.
- Refactored and prettified docker related files. Apart from the ```docker-compose.yml```, now there is a specific file (```docker-compose.dev.yml```) for the development stage, which includes a new service ```api-tests-service``` for running pytest.