### PR TITLE
Add get latest cached weathers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ To run in development mode, which automatically runs the tests, use ```docker-co
 ## Available endpoints
 
 - ```/weather/<city_name>```: Get the weather data for the specified ```city_name```.  If available, cached data is used. Otherwise, new data is fetched from the Open Weather API and cached.
-- ```/weather?max=<max_number>``` (**NOT YET IMPLEMENTED**): Get the weather data for all the cached cities, up to the latest ```max_number``` entries (if specified).
+- ```/weather?max=<max_number>```: Get the weather data for all the cached cities, up to the latest ```max_number``` entries (if specified).

--- a/app/api.py
+++ b/app/api.py
@@ -1,5 +1,5 @@
 import os
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from resources import open_weather
 import data
 import logging
@@ -12,6 +12,13 @@ api = Flask(__name__)
 def get_weather(city_name):
     weather = data.get_weather(city_name)
     return jsonify(weather)
+
+
+@api.route('/weather', methods=['GET'])
+def get_weathers():
+    max = request.args.get('max', default=5, type=int)
+    weathers = data.get_latest_cached_weathers(max)
+    return jsonify(weathers)
 
 
 @api.errorhandler(open_weather.CityNotFound)

--- a/app/data.py
+++ b/app/data.py
@@ -15,4 +15,4 @@ def get_weather(city_name: str) -> dict:
 
 
 def get_latest_cached_weathers(max: int = 5) -> List[dict]:
-    raise NotImplementedError()
+    return WeatherCache.read_latest_weathers(max)

--- a/app/tests/test_api.py
+++ b/app/tests/test_api.py
@@ -7,6 +7,8 @@ from resources.mongo_db import WeatherCache
 
 VALID_CITY_NAME = 'New York'
 INVALID_CITY_NAME = 'Old York'
+VALID_CITIES_NAMES_LIST = [
+    'Paris', 'New York', 'London', 'Bangkok', 'Hong Kong', 'Dubai']
 
 
 @pytest.fixture
@@ -61,3 +63,16 @@ def test_get_weather_cache_expiration(client):
         raise e
     finally:
         WeatherCache.CACHE_EXPIRATION_TIME = weather_cache_expiration_time
+
+
+def test_get_latest_cached_weathers(client):
+    for city_name in VALID_CITIES_NAMES_LIST:
+        _ = client.get('weather/{}'.format(city_name))
+    response = client.get('weather?max=3')
+    response_list = response.get_json()
+    response_city_names = [weather['name'] for weather in response_list]
+    assert(set(response_city_names) == set(VALID_CITIES_NAMES_LIST[-3:]))
+    response = client.get('weather')
+    response_list = response.get_json()
+    response_city_names = [weather['name'] for weather in response_list]
+    assert(set(response_city_names) == set(VALID_CITIES_NAMES_LIST[-5:]))


### PR DESCRIPTION
Through the endpoint ```/weathers?max=n```, the user can now fetch the ```n``` latest cached weathers, with ```n``` defaulting to 5 when the ```max``` parameter is not present.